### PR TITLE
Code formatter

### DIFF
--- a/build_staging/frame.html
+++ b/build_staging/frame.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../src/fontawesome-pro-6.0.0-beta3-web/css/all.min.css">
     <script src="https://kit.fontawesome.com/0ddae54ad8.js" crossorigin="anonymous"></script>
     
-    	<link href="../src/main.css?cachebust=2" rel="stylesheet">
     <script src="frame.js?cachebust=3"></script>
 	<style id="custom-css" type="text/css"></style>
 </head>

--- a/build_staging/frame.js
+++ b/build_staging/frame.js
@@ -20,8 +20,8 @@ function switchTo(mode) {
         updateHTML(localStorage.th_cj, "ace-code-container");
         updateCSS(localStorage.th_cj_css);
 
-        if(parent.importedmeta) {
-            parent.renderProfileMeta(parent.importedmeta);
+        if(localStorage.th_cj_importedmeta) {
+            parent.renderProfileMeta(localStorage.th_cj_importedmeta);
         }
         
         if(mode == "world" || mode.indexOf("profile") != -1 || mode == "warning") {
@@ -55,9 +55,8 @@ function updateHTML(newHTML, div) {
 function importProfile(profilePath, importType){
     if(confirm("Import from Toyhouse? This will overwrite existing "+importType+".")) {
         $.post("get.php", { "profilePath": profilePath, "getMeta": importType=="meta" }, function(data){ 
-            switchTo(parent.activemode);
+            switchTo(parent.sessionSettings.activeMode);
             
-            parent["imported"+importType] = data;
             localStorage["th_cj_imported"+importType] = data;
             
             if(importType=="meta") parent.renderProfileMeta(data);

--- a/build_staging/index.php
+++ b/build_staging/index.php
@@ -19,9 +19,15 @@
         <!-- Misc libraries -->
     	<script src="/src/jquery-3.6.0/jquery-3.6.0.min.js"></script>
         <script src="/src/ace-builds/src-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+        <script src="/src/ace-builds/src-noconflict/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+        <script src="/src/sass.js-master/dist/sass.js"></script>
+
+        
+        <!-- Ace Colorpicker -->
         <link rel="stylesheet" href="/src/ace-colorpicker.css" />
         <script type="text/javascript" src="/src/ace-colorpicker.js" ></script>
-        <script src="/src/sass.js-master/dist/sass.js"></script>
+
+        <!-- Beautify -->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/js-beautify/1.14.7/beautify-css.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/js-beautify/1.14.7/beautify-html.min.js"></script>
         
@@ -90,11 +96,11 @@
     </div>
     
     <div id="main">
-        <iframe src="/build_<?php echo $lastUpdate ?>/frame.html" id="frame" class="d-flex align-self-center">
+        <iframe src="/build_<?php echo $lastUpdate ?>/frame.html?2" id="frame" class="d-flex align-self-center">
         </iframe>
         
         <div id="adjustbar" class="progress-bar progress-bar-striped bg-secondary">
-            <button class="btn btn-primary" id="mobile-switch">
+            <button class="btn btn-primary" id="mobile-switch" onclick="mobileSwitch()">
                 <i class="mobile-switch-arrow fa fa-caret-down"></i>
             </button>
         </div>
@@ -103,14 +109,14 @@
             
             <div id="titles">
                 <div class="field-title html-visible">
-                    <div>
-                        <a class="nav-tab" id="html-tab" onclick="toggleBlurb('html')">HTML</a> &ensp; <a class="nav-tab text-dark" id="blurb-tab" onclick="toggleBlurb('blurb')">Blurb</a>
+                    <div class="panel-title-tabs">
+                        <a class="nav-tab" id="html-tab" onclick="toggleBlurb('html')">HTML</a> &nbsp; <a class="nav-tab text-dark" id="blurb-tab" onclick="toggleBlurb('blurb')">Blurb</a>
                     </div>
                     <span class="panel-options" id="html-options">
                         <a class="edit-button" onclick="editor.undo()" data-toggle="tooltip" title="Undo"><i class="fas fa-undo-alt"></i></a>
                         <a class="edit-button" onclick="editor.redo()" data-toggle="tooltip" title="Redo"><i class="fas fa-redo-alt"></i></a>
                         <a class="edit-button" onclick="editor.insert(loremipsum)" data-toggle="tooltip" title="Insert lorem ipsum"><i class="fas fa-text"></i></a>
-                        <a class="edit-button" onclick="beautifyHTML()" data-toggle="tooltip" title="Format file"><i class="fas fa-brackets-curly"></i></a>
+                        <a class="edit-button" onclick="beautifyHTML()" data-toggle="tooltip" title="Format HTML"><i class="fas fa-brackets-curly"></i></a>
                         <a class="edit-button" onclick="uploadFileDialogue('html')" data-toggle="tooltip" title="Import file"><i class="fa fa-file-import"></i></a>                        
                         <a class="edit-button" onclick="downloadFile('html')" data-toggle="tooltip" title="Save as file"><i class="fa fa-save"></i></a>
                         <a class="edit-button clear-button" id="clear-html" onclick="editor.setValue('')" data-toggle="tooltip" title="Clear"><i class="fa fa-trash"></i></a>
@@ -121,7 +127,7 @@
                     <span class="panel-options" id="css-options">
                         <a class="edit-button" onclick="css_editor.undo()" data-toggle="tooltip" title="Undo"><i class="fas fa-undo-alt"></i></a>
                         <a class="edit-button" onclick="css_editor.redo()" data-toggle="tooltip" title="Redo"><i class="fas fa-redo-alt"></i></a>
-                        <a class="edit-button" onclick="beautifyCSS()" data-toggle="tooltip" title="Format file"><i class="fas fa-brackets-curly"></i></a>
+                        <a class="edit-button" onclick="beautifyCSS()" data-toggle="tooltip" title="Format CSS"><i class="fas fa-brackets-curly"></i></a>
                         <a class="edit-button" onclick="uploadFileDialogue('css')" data-toggle="tooltip" title="Import file"><i class="fa fa-file-import"></i></a>
                         <a class="edit-button" onclick="downloadFile('css')" data-toggle="tooltip" title="Save as file"><i class="fa fa-save"></i></a>
                         <a class="edit-button clear-button" id="clear-css" onclick="css_editor.setValue('')" data-toggle="tooltip" title="Clear"><i class="fa fa-trash"></i></a>
@@ -227,7 +233,7 @@
                     Import from TH
                   </a>
                 
-                  <div class="dropdown-menu px-2" aria-labelledby="dropdownbutton2">
+                  <div class="dropdown-menu px-2" aria-labelledby="dropdownbutton2" onclick="event.stopPropagation()">
                       <div class="d-flex flex-column">
                           <div class="d-flex mb-1">
                             <input type="text" id="char-id" class="form-control mr-1 import-button" placeholder="Enter ID"></input>
@@ -269,19 +275,31 @@
                     <div class="dropdown-menu ui-options px-2" aria-labelledby="dropdownbutton">
 
                         <span class="checkbox-container">
-                            <input type="checkbox" id="html-panel" onclick="setHTMLPanel();" checked="true">&nbsp;<label for="html-panel">HTML</label>
+                            <input type="checkbox" id="html-panel" onclick="toggleHTMLPanel();" checked="true">&nbsp;<label for="html-panel">HTML</label>
                         </span>
 
                         <span class="checkbox-container">
-                            <input type="checkbox" id="css-panel" onclick="setCSSPanel();" checked="true">&nbsp;<label for="css-panel">CSS</label>
+                            <input type="checkbox" id="css-panel" onclick="toggleCSSPanel();" checked="true">&nbsp;<label for="css-panel">CSS</label>
                         </span>
 
                         <span class="checkbox-container">
-                            <input type="checkbox" id="text-panel" onclick="setTextPanel();" checked="true">&nbsp;<label for="text-panel">Scratchpad</label>
+                            <input type="checkbox" id="text-panel" onclick="toggleTextPanel();" checked="true">&nbsp;<label for="text-panel">Scratchpad</label>
+                        </span>
+
+                        <span class="checkbox-container">
+                            <input type="checkbox" id="autocomplete" onclick="toggleAutocomplete();"> <label for="autocomplete">Autocomplete</label>
                         </span>
 
                         <span class="checkbox-container hide-small">
-                            <input type="checkbox" id="vertical" onchange="toggleVertical()">&nbsp;<label for="vertical" class="hide-small">Vertical</label>
+                            <input type="checkbox" id="colorpicker" onchange="toggleColorpicker()" checked="true">&nbsp;<label for="colorpicker">Colorpicker</label>
+                        </span>
+
+                        <span class="checkbox-container hide-small">
+                            <input type="checkbox" id="vertical" onchange="toggleVertical()">&nbsp;<label for="vertical" class="hide-small">Vertical view</label>
+                        </span>
+
+                        <span class="checkbox-container hide-small">
+                            <input type="checkbox" id="gutter" onchange="toggleGutter()">&nbsp;<label for="gutter">Line numbers</label>
                         </span>
 
                         <span class="checkbox-container">
@@ -289,11 +307,11 @@
                         </span>
 
                         <span class="checkbox-container">
-                            <input type="checkbox" id="big-text" onclick="toggleBigFont();"> <label for="big-text">Big text</label>
+                            <input type="checkbox" id="big-text" onclick="toggleBigText();"> <label for="big-text">Big text</label>
                         </span>
                     </div>
                 </div>
-                <a class="btn btn-primary update-btn d-inline-block" id="update-preview" onclick="updateCode()" href="#">Update preview</a>
+                <a class="btn btn-primary update-btn d-inline-block" id="update-preview" onclick="updateHTML(); updateCSS();" href="#">Update preview</a>
             </div>
             
             <input type="file" class="d-none" id="fileupload" onclick="uploadFile(this)">

--- a/build_staging/index.php
+++ b/build_staging/index.php
@@ -22,6 +22,8 @@
         <link rel="stylesheet" href="/src/ace-colorpicker.css" />
         <script type="text/javascript" src="/src/ace-colorpicker.js" ></script>
         <script src="/src/sass.js-master/dist/sass.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/js-beautify/1.14.7/beautify-css.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/js-beautify/1.14.7/beautify-html.min.js"></script>
         
         <!-- TH source -->
     	<link id="theme-css" href="/src/site_black-forest.css?cachebust=2" rel="stylesheet">
@@ -108,6 +110,7 @@
                         <a class="edit-button" onclick="editor.undo()" data-toggle="tooltip" title="Undo"><i class="fas fa-undo-alt"></i></a>
                         <a class="edit-button" onclick="editor.redo()" data-toggle="tooltip" title="Redo"><i class="fas fa-redo-alt"></i></a>
                         <a class="edit-button" onclick="editor.insert(loremipsum)" data-toggle="tooltip" title="Insert lorem ipsum"><i class="fas fa-text"></i></a>
+                        <a class="edit-button" onclick="beautifyHTML()" data-toggle="tooltip" title="Format file"><i class="fas fa-brackets-curly"></i></a>
                         <a class="edit-button" onclick="uploadFileDialogue('html')" data-toggle="tooltip" title="Import file"><i class="fa fa-file-import"></i></a>                        
                         <a class="edit-button" onclick="downloadFile('html')" data-toggle="tooltip" title="Save as file"><i class="fa fa-save"></i></a>
                         <a class="edit-button clear-button" id="clear-html" onclick="editor.setValue('')" data-toggle="tooltip" title="Clear"><i class="fa fa-trash"></i></a>
@@ -118,7 +121,7 @@
                     <span class="panel-options" id="css-options">
                         <a class="edit-button" onclick="css_editor.undo()" data-toggle="tooltip" title="Undo"><i class="fas fa-undo-alt"></i></a>
                         <a class="edit-button" onclick="css_editor.redo()" data-toggle="tooltip" title="Redo"><i class="fas fa-redo-alt"></i></a>
-                        
+                        <a class="edit-button" onclick="beautifyCSS()" data-toggle="tooltip" title="Format file"><i class="fas fa-brackets-curly"></i></a>
                         <a class="edit-button" onclick="uploadFileDialogue('css')" data-toggle="tooltip" title="Import file"><i class="fa fa-file-import"></i></a>
                         <a class="edit-button" onclick="downloadFile('css')" data-toggle="tooltip" title="Save as file"><i class="fa fa-save"></i></a>
                         <a class="edit-button clear-button" id="clear-css" onclick="css_editor.setValue('')" data-toggle="tooltip" title="Clear"><i class="fa fa-trash"></i></a>

--- a/build_staging/script.js
+++ b/build_staging/script.js
@@ -13,6 +13,8 @@ let sessionSettings = {isBlurb: false, mobileView: false};
 var cssPanel, textPanel, editor, css_editor, text_editor, frame, importedmeta, importedcode;
 const loremipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sollicitudin elit sed tellus blandit viverra sed eget odio. Donec accumsan tempor lacus, et venenatis elit feugiat non. Duis porta eros et velit blandit dapibus. Curabitur ac finibus eros. Duis placerat velit vitae massa sodales, eget mattis nibh pellentesque.";
 const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const beautify_HTML_Options = { "indent_size": "1", "indent_char": "\t", "max_preserve_newlines": "-1", "preserve_newlines": false, "keep_array_indentation": false, "break_chained_methods": false, "indent_scripts": "normal", "brace_style": "expand", "space_before_conditional": true, "unescape_strings": false, "jslint_happy": false, "end_with_newline": false, "wrap_line_length": "0", "indent_inner_html": false, "comma_first": false, "e4x": false, "indent_empty_lines": false }
+const beautify_CSS_Options = { "indent_size": "2", "indent_char": " ", "max_preserve_newlines": "-1", "preserve_newlines": false, "keep_array_indentation": false, "break_chained_methods": false, "indent_scripts": "normal", "brace_style": "collapse", "space_before_conditional": true, "unescape_strings": false, "jslint_happy": false, "end_with_newline": false, "wrap_line_length": "0", "indent_inner_html": false, "comma_first": false, "e4x": false, "indent_empty_lines": false };
 
 // Initialisation of web app is housed inside the window.onload event listener. TODO: Make this promise-based, i.e. upon loading all required files
 $(window).on("load", function(){
@@ -319,6 +321,16 @@ function updateCSS() {
 function updateText() {
     localStorage.th_cj_text = text_editor.getValue();
 };
+
+function beautifyHTML() {
+    var beautifiedText = html_beautify(editor.getValue(), beautify_HTML_Options);
+    editor.session.setValue(beautifiedText);
+}
+
+function beautifyCSS() {
+    var beautifiedText = css_beautify(css_editor.getValue(), beautify_CSS_Options);
+    css_editor.session.setValue(beautifiedText);
+}
 
 function showInfo() {
     localStorage.th_cj_hidenotif2 = "true";

--- a/build_staging/script.js
+++ b/build_staging/script.js
@@ -324,12 +324,14 @@ function updateText() {
 
 function beautifyHTML() {
     var beautifiedText = html_beautify(editor.getValue(), beautify_HTML_Options);
-    editor.session.setValue(beautifiedText);
+    editor.setValue(beautifiedText);
+    editor.clearSelection();
 }
 
 function beautifyCSS() {
     var beautifiedText = css_beautify(css_editor.getValue(), beautify_CSS_Options);
-    css_editor.session.setValue(beautifiedText);
+    css_editor.setValue(beautifiedText);
+    css_editor.clearSelection();
 }
 
 function showInfo() {

--- a/build_staging/script.js
+++ b/build_staging/script.js
@@ -1,41 +1,49 @@
-// Setup variables. TODO: Put everything in a container object
-var showval = "\<!-- Enter HTML here... --\>";
-var activemode = "profile";
-var activetheme = "Default";
-var showcss = "\/* Enter CSS here... *\/";
-var showtext = "Paste drafts and snippets here...";
+/**************************************
+    vvv  Setup variables  vvv
+**************************************/
+// TODO: Put everything in sessionSettings object
+// TODO: better way to determine if device is mobile (specifically to target desktop Safari for weird flex sizing) or a more elegant fix for weird sizing
 const isSafari = navigator.userAgent.indexOf("Safari") > -1;
 const isMobile = typeof screen.orientation !== 'undefined';
-var htmlChanged = true;
-var cssChanged = true;
-var textChanged = true;
-let sessionSettings = {isBlurb: false, mobileView: false};
-var cssPanel, textPanel, editor, css_editor, text_editor, frame, importedmeta, importedcode;
+var sessionSettings = { activeMode: "profile", activeTheme: "Default", isBlurb: false, HTMLChanged: true, CSSChanged: true, textChanged: true, colorpicker: true };
+// DOM elements
+var editor, css_editor, text_editor, frame;
+
+
+/**************************************
+    vvv  Constants  vvv
+**************************************/
+const defaultHTML = "\<!-- Enter HTML here... --\>";
+const defaultCSS = "\/* Enter CSS here... *\/";
+const defaultText =  "Paste drafts and snippets here...";
 const loremipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sollicitudin elit sed tellus blandit viverra sed eget odio. Donec accumsan tempor lacus, et venenatis elit feugiat non. Duis porta eros et velit blandit dapibus. Curabitur ac finibus eros. Duis placerat velit vitae massa sodales, eget mattis nibh pellentesque.";
 const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 const beautify_HTML_Options = { "indent_size": "1", "indent_char": "\t", "max_preserve_newlines": "-1", "preserve_newlines": false, "keep_array_indentation": false, "break_chained_methods": false, "indent_scripts": "normal", "brace_style": "expand", "space_before_conditional": true, "unescape_strings": false, "jslint_happy": false, "end_with_newline": false, "wrap_line_length": "0", "indent_inner_html": false, "comma_first": false, "e4x": false, "indent_empty_lines": false }
 const beautify_CSS_Options = { "indent_size": "2", "indent_char": " ", "max_preserve_newlines": "-1", "preserve_newlines": false, "keep_array_indentation": false, "break_chained_methods": false, "indent_scripts": "normal", "brace_style": "collapse", "space_before_conditional": true, "unescape_strings": false, "jslint_happy": false, "end_with_newline": false, "wrap_line_length": "0", "indent_inner_html": false, "comma_first": false, "e4x": false, "indent_empty_lines": false };
 
-// Initialisation of web app is housed inside the window.onload event listener. TODO: Make this promise-based, i.e. upon loading all required files
+
+/**************************************
+    vvv  Window events  vvv
+**************************************/
+
 $(window).on("load", function(){
+    // Web app is initialised here, as code should only start running after all DOM elements are loaded.
+    // TODO: Make this promise-based, i.e. upon loading all required files
 
     // Get frame and set frame's internal lastUpdate to parent lastUpdate
     frame = document.getElementById("frame");
     frame.contentWindow.lastUpdate = lastUpdate;
 
-    const showChar = location.hash.substring(1);
-    if(location.hash.substring(1)) {
-        frame.contentWindow.importProfile(showChar);
-    }
-
     $(".ui-options").click(function(e){
         e.stopPropagation();
     })
     
+    // Import notes, changelog, version list etc.
     loadNotes();
-    loadLocal();
+    
+    // initEditors must be called before loadLocalSettings so that editors are initialised before changing their appearance.
     initEditors();
-    toggleUITheme();
+    loadLocalSettings();
     
     // Init click/touch events. Needs tidying and Safari compatibility
     $("#adjustbar").mousedown(function(){
@@ -56,86 +64,36 @@ $(window).on("load", function(){
         $(window).on("touchend", cancelDrag);
     });
     
-    $("#mobile-switch").on("click", mobileSwitch);
-
-
-    // Set blank ACE text field behaviour
+    updateHTML();
+    updateCSS();
+    switchTo(sessionSettings.activeMode);
+    toggleTheme(sessionSettings.activeTheme);
     
-    updateCode();
-    switchTo(activemode);
-    toggleTheme(activetheme);
-    resizeElements();
-    setHTMLPanel();
-    setCSSPanel();
-    setTextPanel();
-    
-    // Ugly solution to not updating screen every time the user enters a new character.
-    // TODO: Needs tidier behaviour e.g. a "queue" or something where each update request cancels the last.
-    var tick = setInterval(function() {
-        if($("#auto").prop("checked")) {
-            if(htmlChanged) {
-                if(editor.getValue()) {
-                    $("#clear-html")
-                        .html("<i class='fa fa-trash'></i>")
-                        .attr("data-original-title", "Clear")
-                        .removeData("justcleared");
-                    if(editor.getValue()=="Please reset!") {
-                        var confirmReset = confirm("Really hard reset? You will lose all drafts and settings.");
-                        if(confirmReset === true) hardReset();
-                        else editor.setValue("");
-                    }
-                }
-                updateHTML();
-                htmlChanged=false;
-            }
-            
-            if(cssChanged) {
-                if(css_editor.getValue()) {
-                    $("#clear-css")
-                        .html("<i class='fa fa-trash'></i>")
-                        .attr("data-original-title", "Clear")
-                        .removeData("justcleared");
-                }
-                updateCSS();
-                cssChanged=false;
-            }
-            
-            if(textChanged) {
-                if(text_editor.getValue()) {
-                    $("#clear-text")
-                        .html("<i class='fa fa-trash'></i>")
-                        .attr("data-original-title", "Clear")
-                        .removeData("justcleared");
-                }
-                updateText();
-                textChanged=false;
-            }
-        }
-    }, 1000);
-    
-    $("#import .dropdown-menu").click(function(e){
-        e.stopPropagation();
-    });
-
-    $(window).keypress(function(e){
-        if(e.keyCode == 10 && e.ctrlKey) {
-            e.preventDefault();
-            updateCode();
-        }
-    });
+    // Start tick function that runs every second
+    setInterval(tick, 1000);
     
     $(window).resize(function(){
-        resizeElements();
+        resizeScreen();
         resizeEditors();
     });
     
     setTimeout(function(){
         $("#loader").addClass("invisible");
+        resizeScreen();
+        resizeEditors();
+        // This is an ugly solution, waiting .5 seconds before resizing the editors tends to ensure they resize to fit the content after the content is loaded.
     }, 500);
 });
 
-// TODO: Change this to promise-based
+$(window).on("beforeunload", function() {
+    if(editor.getValue() && editor.getValue() !== defaultHTML) localStorage.th_cj_backup = editor.getValue();
+});
+
+
 function loadNotes() {
+    // Get the current meta info and imports it into the info modal.
+    // TODO: Change this to promise-based
+
     $.get("../known-issues.html?"+lastUpdate, function(data) {
         $("#issues-text").html(data);
     });
@@ -156,34 +114,34 @@ function loadNotes() {
     });
 }
 
-// TODO: Use destructuring of localStorage object to tidy this up
-function loadLocal() {
-    if(localStorage.th_cj) {
-        showval = localStorage.th_cj;
+
+function loadLocalSettings() {
+    // Extract the user's settings and content from local storage and update UI + editors.
+    // TODO: Use destructuring of localStorage object to tidy this up
+
+    editor.setValue( localStorage.th_cj ? localStorage.th_cj : defaultHTML );
+    css_editor.setValue( localStorage.th_cj_css ? localStorage.th_cj_css : defaultCSS );
+    text_editor.setValue( localStorage.th_cj_text ? localStorage.th_cj_text : defaultText );
+    
+    if(localStorage.th_cj_colorpicker) {
+        $("#colorpicker").prop("checked", localStorage.th_cj_colorpicker == "true");
+        toggleColorpicker();
     }
     
     if(localStorage.th_cj_mode) {
-        activemode = localStorage.th_cj_mode;
+        sessionSettings.activeMode = localStorage.th_cj_mode;
     }
     
     if(localStorage.th_cj_theme) {
-        activetheme = localStorage.th_cj_theme;
-    }
-    
-    if(localStorage.th_cj_css) {
-        showcss = localStorage.th_cj_css;
-    }
-    
-    if(localStorage.th_cj_text) {
-        showtext = localStorage.th_cj_text;
+        sessionSettings.activeTheme = localStorage.th_cj_theme;
     }
     
     if(localStorage.th_cj_importedmeta) {
-       importedmeta = localStorage.th_cj_importedmeta;
+       //importedmeta = localStorage.th_cj_importedmeta;
     }
     
     if(localStorage.th_cj_importedcode) {
-       importedcode = localStorage.th_cj_importedcode;
+       //importedcode = localStorage.th_cj_importedcode;
     }
     
     if(localStorage.th_cj_vertical) {
@@ -191,20 +149,33 @@ function loadLocal() {
         toggleVertical();
     }
     
+    if(localStorage.th_cj_gutter) {
+        $("#gutter").prop("checked", localStorage.th_cj_gutter == "true");
+        toggleGutter();
+    }
+    
+    if(localStorage.th_cj_lowContrast) {
+        $("#low-contrast").prop("checked", localStorage.th_cj_lowContrast == "true");
+        toggleUITheme();
+    }
+    
     if(localStorage.th_cj_htmlpanel) {
         $("#html-panel").prop("checked", localStorage.th_cj_htmlpanel == "true");
+        toggleHTMLPanel();
     }
     
     if(localStorage.th_cj_csspanel) {
         $("#css-panel").prop("checked", localStorage.th_cj_csspanel == "true");
+        toggleCSSPanel();
     }
     
     if(localStorage.th_cj_textpanel) {
         $("#text-panel").prop("checked", localStorage.th_cj_textpanel == "true");
+        toggleTextPanel();
     }
     
     if(localStorage.th_cj_bigtext) {
-        if(localStorage.th_cj_bigtext == "true") $(".editor-panel").addClass("big-text");
+        if(localStorage.th_cj_bigtext == "true") toggleBigText();
         $("#big-text").prop("checked", localStorage.th_cj_bigtext == "true");
     }
     
@@ -212,110 +183,131 @@ function loadLocal() {
         $("#auto").prop("checked", localStorage.th_cj_auto == "true");
     }
     
+    if(localStorage.th_cj_mobile) {
+        $("#mobile").prop("checked", localStorage.th_cj_mobile == "true");
+        toggleMobilePreview();
+    }
+    
+    if(localStorage.th_cj_autocomplete) {
+        $("#autocomplete").prop("checked", localStorage.th_cj_autocomplete == "true");
+        toggleAutocomplete();
+    }
+    
     if(localStorage.th_cj_lastUpdate != lastUpdate && location.pathname.indexOf("/unstable") == -1) {
         $("#info").removeClass("d-none");
         $("#info-back").removeClass("d-none");
         localStorage.th_cj_lastUpdate = lastUpdate;
     }
-    
-    if(localStorage.th_cj_lowContrast) {
-        $("#low-contrast").prop("checked", localStorage.th_cj_lowContrast == "true");
-    }
 }
 
 function initEditors() {
+    // Initialise the three Ace editors on the page with initial settings.
 
     editor = ace.edit("html-editor");
     editor.session.setMode("ace/mode/html", () => {
-        editor.setValue(showval);
-        AceColorPicker.load(ace, editor);
+        if($("#colorpicker").prop("checked")) toggleColorpicker();
     });
     sessionSettings.isBlurb = false;
     editor.setShowPrintMargin(false);
     editor.session.setUseWrapMode(true);
     editor.session.on("change", function(){
-        htmlChanged=true;
+        sessionSettings.HTMLChanged=true;
     });
     editor.on("focus", function() {
-        if(editor.getValue()=="<!-- Enter HTML here... -->") editor.setValue("");
+        if(editor.getValue()==defaultHTML) editor.setValue("");
     });
     
     css_editor = ace.edit("css-editor");
     css_editor.session.setMode("ace/mode/scss", () => {
-        css_editor.setValue(showcss);
-        AceColorPicker.load(ace, css_editor);
+        if($("#colorpicker").prop("checked")) toggleColorpicker();
     });
     css_editor.setShowPrintMargin(false);
     css_editor.session.setUseWrapMode(true);
     css_editor.session.on("change", function(){
-        cssChanged = true;
+        sessionSettings.CSSChanged = true;
     });
     css_editor.on("focus", function() {
-        if(css_editor.getValue()=="\/* Enter CSS here... *\/") css_editor.setValue("");
+        if(css_editor.getValue()==defaultCSS) css_editor.setValue("");
     })
 
     text_editor = ace.edit("text-editor");
     text_editor.setShowPrintMargin(false);
     text_editor.renderer.setShowGutter(false);
-    text_editor.setValue(showtext);
     text_editor.session.setUseWrapMode(true);
     text_editor.session.on("change", function(){
-        textChanged = true;
+        sessionSettings.textChanged = true;
     });
     text_editor.on("focus", function() {
-        if(text_editor.getValue()=="Paste drafts and snippets here...") text_editor.setValue("");
+        if(text_editor.getValue()==defaultText) text_editor.setValue("");
     })
 
 }
 
-function toggleTheme(theme) {
-    activetheme = theme;
-    localStorage.th_cj_theme = theme;
-    if(frame){
-        frame.contentWindow.toggleTheme(theme);
+function tick() {
+    // Ugly solution to not updating screen every time the user enters a new character.
+    // TODO: Needs tidier behaviour e.g. a "queue" or something where each update request cancels the last.
+    // TODO: When auto is unchecked, still update local storage
+
+    if(sessionSettings.HTMLChanged) {
+        if(editor.getValue().indexOf("Please reset!") !== -1) {
+            editor.setValue( editor.getValue().replace("Please reset!", "") );
+            hardReset();
+        } else {
+            updateHTML();
+            sessionSettings.HTMLChanged=false;
+        }
     }
+    
+    if(sessionSettings.CSSChanged) {
+        updateCSS();
+        sessionSettings.CSSChanged=false;
+    }
+    
+    if(sessionSettings.textChanged) {
+        updateText();
+        sessionSettings.textChanged=false;
+    }
+
 }
 
-function switchTo(mode) {
-    activemode = mode;
-    localStorage.th_cj_mode = mode;
-    frame.contentWindow.switchTo(mode);
-}
 
-function updateCode(){
-    updateHTML();
-    updateCSS();
-}
+/**************************************
+    vvv  Code update functions  vvv
+**************************************/
 
 function updateHTML(){
-    var val = editor.getValue();
-    let updateDiv;
+    let val = editor.getValue();
+    let updateEditor;
     if(sessionSettings.isBlurb) {
         localStorage.th_cj_blurb = val;
-        updateDiv = "ace-code-container-2";
+        updateEditor = "ace-code-container-2";
     } else {
         localStorage.th_cj = val;
-        updateDiv = "ace-code-container";
+        updateEditor = "ace-code-container";
     }
-    val = val.replace(/(<\/*)(script|style|head)(.*>)/g, "$1div$3");
-    frame.contentWindow.updateHTML(val, updateDiv);
+
+    if($("#auto").prop("checked")) {
+        val = val.replace(/(<\/*)(script|style|head)(.*>)/g, "$1div$3");
+        frame.contentWindow.updateHTML(val, updateEditor);
+    }
 };
 
 function updateCSS() {
     var sass = new Sass();
     var raw_css = css_editor.getValue();
-    
-    if(raw_css) {
-        sass.compile(raw_css, function(result) {
-            let css = result.text;
-            if(css) frame.contentWindow.updateCSS(css);
-            else frame.contentWindow.updateCSS(raw_css);
-        });
-    } else {
-        frame.contentWindow.updateCSS("");
-    }
-    
     localStorage.th_cj_css = raw_css;
+    
+    if($("#auto").prop("checked")) {
+        if(raw_css) {
+            sass.compile(raw_css, function(result) {
+                let css = result.text;
+                if(css) frame.contentWindow.updateCSS(css);
+                else frame.contentWindow.updateCSS(raw_css);
+            });
+        } else {
+            frame.contentWindow.updateCSS("");
+        }
+    }
 }
 
 function updateText() {
@@ -334,46 +326,13 @@ function beautifyCSS() {
     css_editor.clearSelection();
 }
 
-function showInfo() {
-    localStorage.th_cj_hidenotif2 = "true";
-    $("#info").toggleClass("d-none");
-}
 
-function setHTMLPanel() {
-    htmlPanel = $("#html-panel").prop("checked");
-    if(htmlPanel){
-        $(".html-visible").removeClass("d-none");
-    } else $(".html-visible").addClass("d-none");
-    localStorage.th_cj_htmlpanel = htmlPanel;
-    resizeEditors();
-}
+/**************************************
+    vvv  Sizing functions  vvv
+**************************************/
 
-function setCSSPanel() {
-    cssPanel = $("#css-panel").prop("checked");
-    if(cssPanel){
-        $(".css-visible").removeClass("d-none");
-    } else $(".css-visible").addClass("d-none");
-    localStorage.th_cj_csspanel = cssPanel;
-    resizeEditors();
-}
-
-function setTextPanel() {
-    textPanel = $("#text-panel").prop("checked");
-    if(textPanel){
-        $(".text-visible").removeClass("d-none");
-    } else {
-        $(".text-visible").addClass("d-none");
-    }
-    localStorage.th_cj_textpanel = textPanel;
-    resizeEditors();
-}
-
-function toggleBigFont() {
-    $(".ace_editor").toggleClass("big-text");
-    localStorage.th_cj_bigtext = $("#big-text").prop("checked");
-}
-
-function resizeElements() {
+function resizeScreen() {
+    // This function resizes the main element (where preview window and Ace panels are located) after screen size changes e.g. rotating device.
     if(screen.width < 576) {
         if(!$("#main").hasClass("mobile-display")) {
             $("#main").addClass("mobile-display");
@@ -383,22 +342,8 @@ function resizeElements() {
     }
 }
 
-function resizeEditors() {
-
-    if(isSafari && !isMobile) {
-        if(! $("#vertical").prop("checked")) {
-            $(".ace_editor").css("height", window.innerHeight - $("#frame").height() - $("#adjustbar").height() - $("#footer").height() - $("#titles").height());
-        } else {
-            $(".ace_editor").css("width", window.innerWidth - $("#frame").width() - $("#adjustbar").width() - $("#footer").width() - $("#titles").width());
-        }
-    }
-
-    editor.resize();
-    css_editor.resize();
-    text_editor.resize();
-}
-
-function initHeight(newheight, newwidth) {
+function resizeFrame(newheight, newwidth) {
+    // This function resizes the frame element, usually after the drag bar has been moved.
     if(!newheight) {
         newheight = window.innerHeight*0.55;
     }
@@ -410,9 +355,22 @@ function initHeight(newheight, newwidth) {
     
     $("#frame").css("height", newheight);
     
-    if(editor) {
-        resizeEditors();
+    if(editor) resizeEditors();
+}
+
+function resizeEditors() {
+    // This function resizes the Ace editors to fill the space left by the preview window, useful after preview window has changed size. On Safari, which handles flex differently, this includes forcibly setting the width/height of the editors.
+    if(isSafari && !isMobile) {
+        if(! $("#vertical").prop("checked")) {
+            $(".ace_editor").css("height", window.innerHeight - $("#frame").height() - $("#adjustbar").height() - $("#footer").height() - $("#titles").height());
+        } else {
+            $(".ace_editor").css("width", window.innerWidth - $("#frame").width() - $("#adjustbar").width() - $("#footer").width() - $("#titles").width());
+        }
     }
+
+    editor.resize();
+    css_editor.resize();
+    text_editor.resize();
 }
 
 function dragHandler(e) {
@@ -452,6 +410,26 @@ function cancelDrag(e) {
     $(frame.contentWindow).off("touchmove");
     $(frame.contentWindow).off("touchend");
 }
+
+function mobileSwitch() {
+    event.stopPropagation();
+    if(!$("#editor").hasClass("d-none")) {
+        $("#editor").addClass("d-none");
+        $("#footer").addClass("d-none");
+        $("#frame").addClass("expanded");
+        $("#mobile-switch").html("<i class='fa fa-caret-up'></i>");
+    } else {
+        $("#editor").removeClass("d-none");
+        $("#footer").removeClass("d-none");
+        $("#frame").removeClass("expanded");
+        $("#mobile-switch").html("<i class='fa fa-caret-down'></i>");
+    }
+}
+
+
+/**************************************
+    vvv  Local file upload/download functions  vvv
+**************************************/
 
 function downloadFile(panel) {
     var thedate = new Date();
@@ -494,34 +472,10 @@ function uploadFile(div){
     
 }
 
-function mobileSwitch(e) {
-    e.stopPropagation();
-    if(!$("#editor").hasClass("d-none")) {
-        $("#editor").addClass("d-none");
-        $("#footer").addClass("d-none");
-        $("#frame").addClass("expanded");
-        $("#mobile-switch").html("<i class='fa fa-caret-up'></i>");
-    } else {
-        $("#editor").removeClass("d-none");
-        $("#footer").removeClass("d-none");
-        $("#frame").removeClass("expanded");
-        $("#mobile-switch").html("<i class='fa fa-caret-down'></i>");
-    }
-}
 
-function shrinkGrow(div) {
-    if(!$(div).hasClass("shrunk")) {
-        $(div).css("width", "10%");
-        $(div).css("height", "10%");
-        $(div).css("opacity", "0.5");
-        $(div).addClass("shrunk");
-    } else {
-        $(div).css("width", "40%");
-        $(div).css("height", "90%");
-        $(div).css("opacity", "1");
-        $(div).removeClass("shrunk");
-    }
-}
+/**************************************
+    vvv  TH import functions  vvv
+**************************************/
 
 function startImport(importType){
     frame.contentWindow.importProfile($("#char-id").val(), importType);
@@ -530,7 +484,7 @@ function startImport(importType){
 function renderProfileCode(data) {
         let customCSS;
 
-        if(data.indexOf("<style>") > -1) {
+        if(data.indexOf("<style>") !== -1) {
             customCSS = data.split("<style>")[1].split("</style>")[0].replace("<![CDATA[", "").replace("]]>", "").trim();
         }
 
@@ -559,6 +513,17 @@ function renderProfileMeta(data) {
         frame.contentWindow.$(".blurb").addClass("ace-code-container-2");
         localStorage.th_cj_blurb = $(data).find(".blurb").html();
         if(sessionSettings.isBlurb) editor.setValue(localStorage.th_cj_blurb);
+
+}
+
+
+/**************************************
+    vvv  UI functionality  vvv
+**************************************/
+
+function showInfo() {
+    localStorage.th_cj_hidenotif2 = "true";
+    $("#info").toggleClass("d-none");
 }
 
 function hardReset() {
@@ -578,6 +543,8 @@ function hardReset() {
     localStorage.removeItem("th_cj_csspanel");
     localStorage.removeItem("th_cj_textpanel");
     localStorage.removeItem("th_cj_auto");
+    localStorage.removeItem("th_cj_mobile");
+    localStorage.removeItem("th_cj_gutter");
     localStorage.removeItem("th_cj_lastUpdate");
     localStorage.removeItem("th_cj_hidenotif");
     localStorage.removeItem("th_cj_hidenotif2");
@@ -594,12 +561,69 @@ function insertLorem(panel) {
     }
 }
 
-// TOGGLERS
+/**************************************
+    vvv  UI toggles  vvv
+**************************************/
+
+function toggleTheme(theme) {
+    sessionSettings.activeTheme = theme;
+    localStorage.th_cj_theme = theme;
+    if(frame){
+        frame.contentWindow.toggleTheme(theme);
+    }
+}
+
+function switchTo(mode) {
+    sessionSettings.activeMode = mode;
+    localStorage.th_cj_mode = mode;
+    frame.contentWindow.switchTo(mode);
+}
+
+function toggleBlurb() {
+    if(sessionSettings.isBlurb) {
+        $("#html-tab").removeClass("text-dark");
+        $("#blurb-tab").addClass("text-dark");
+        editor.setValue(localStorage.th_cj);
+    } else {
+        $("#blurb-tab").removeClass("text-dark");
+        $("#html-tab").addClass("text-dark");
+        editor.setValue(localStorage.th_cj_blurb);
+    }
+    sessionSettings.isBlurb = !sessionSettings.isBlurb;
+}
+
+function toggleHTMLPanel() {
+    htmlPanel = $("#html-panel").prop("checked");
+    if(htmlPanel){
+        $(".html-visible").removeClass("d-none");
+    } else $(".html-visible").addClass("d-none");
+    localStorage.th_cj_htmlpanel = htmlPanel;
+    resizeEditors();
+}
+
+function toggleCSSPanel() {
+    if( $("#css-panel").prop("checked") ){
+        $(".css-visible").removeClass("d-none");
+    } else $(".css-visible").addClass("d-none");
+    localStorage.th_cj_csspanel = $("#css-panel").prop("checked");
+    resizeEditors();
+}
+
+function toggleTextPanel() {
+    if( $("#text-panel").prop("checked") ){
+        $(".text-visible").removeClass("d-none");
+    } else {
+        $(".text-visible").addClass("d-none");
+    }
+    localStorage.th_cj_textpanel = $("#text-panel").prop("checked");
+    resizeEditors();
+}
  
 function toggleAuto() {
     localStorage.th_cj_auto = $("#auto").prop("checked");
     if($("#auto").prop("checked")) {
-        updateCode();
+        updateHTML();
+        updateCSS();
     }
 }
 
@@ -646,30 +670,27 @@ function toggleVertical() {
         codewidth = "100%";
     }
     
-    initHeight(codeheight, codewidth);
+    resizeFrame(codeheight, codewidth);
 }
 
 function toggleMobilePreview() {
-    if($("#mobile").prop("checked")) {
-        $("#frame").addClass("mobile-preview");
-    } else $("#frame").removeClass("mobile-preview");
+    localStorage.th_cj_mobile = $("#mobile").prop("checked");
+    if($("#mobile").prop("checked")) $("#frame").addClass("mobile-preview");
+    else $("#frame").removeClass("mobile-preview");
+    resizeEditors();
 }
 
 function toggleUITheme(){
-
     localStorage.th_cj_lowContrast = $("#low-contrast").prop("checked");
 
     if($("#low-contrast").prop("checked")) { 
-
         $("#theme-css").attr("href", "../src/site_night-forest.css");
         $(".bg-light").removeClass("bg-light").addClass("bg-dark");
-
         editor.setTheme("ace/theme/tomorrow_night");
         css_editor.setTheme("ace/theme/tomorrow_night");
         text_editor.setTheme("ace/theme/tomorrow_night");
 
     } else {
-        
         $("#theme-css").attr("href", "../src/site_black-forest.css")
         $(".bg-dark").removeClass("bg-dark").addClass("bg-light");
 
@@ -680,16 +701,64 @@ function toggleUITheme(){
 
 }
 
-function toggleBlurb() {
-    if(sessionSettings.isBlurb) {
-        sessionSettings.isBlurb = false;
-        $("#html-tab").removeClass("text-dark");
-        $("#blurb-tab").addClass("text-dark");
-        editor.setValue(localStorage.th_cj);
+function toggleBigText() {
+    localStorage.th_cj_bigtext = $("#big-text").prop("checked");
+    if($("#big-text").prop("checked")) $(".ace_editor").addClass("big-text");
+    else  $(".ace_editor").removeClass("big-text");
+}
+
+function toggleGutter() {
+    localStorage.th_cj_gutter = $("#gutter").prop("checked");
+
+    if($("#gutter").prop("checked")) { 
+        editor.renderer.setShowGutter(true);
+        css_editor.renderer.setShowGutter(true);
+        
     } else {
-        sessionSettings.isBlurb = true;
-        $("#blurb-tab").removeClass("text-dark");
-        $("#html-tab").addClass("text-dark");
-        editor.setValue(localStorage.th_cj_blurb);
+        editor.renderer.setShowGutter(false);
+        css_editor.renderer.setShowGutter(false);
+    }
+
+}
+
+function toggleAutocomplete() {
+    localStorage.th_cj_autocomplete = $("#autocomplete").prop("checked");
+    if($("#autocomplete").prop("checked")) {
+        editor.setOptions({behavioursEnabled: true});
+        css_editor.setOptions({behavioursEnabled: true});
+    } else {
+        editor.setOptions({behavioursEnabled: false});
+        css_editor.setOptions({behavioursEnabled: false});
+    }
+}
+
+function toggleColorpicker() {
+    localStorage.th_cj_colorpicker = $("#colorpicker").prop("checked");
+
+    if( !$("#colorpicker").prop("checked") ) {
+        [editor.session, css_editor.session].forEach(function(session){
+
+            let rules = session.$mode.$highlightRules.getRules();
+            for (let stateName in rules) {
+                rules[stateName].map(
+                    i => {
+                        if(i.token == "color" && i.regex == '#(?:[\\da-f]{8})|#(?:[\\da-f]{3}){1,2}|rgb\\((?:\\s*\\d{1,3},\\s*){2}\\d{1,3}\\s*\\)|rgba\\((?:\\s*\\d{1,3},\\s*){3}\\d*\\.?\\d+\\s*\\)|hsl\\(\\s*\\d{1,3}(?:,\\s*\\d{1,3}%){2}\\s*\\)|hsla\\(\\s*\\d{1,3}(?:,\\s*\\d{1,3}%){2},\\s*\\d*\\.?\\d+\\s*\\)') delete i.regex;
+                    }
+                );
+            }
+            // force recreation of tokenizer
+            session.$mode.$tokenizer = null;
+            session.bgTokenizer.setTokenizer(session.$mode.getTokenizer());
+            // force re-highlight whole document
+            session.bgTokenizer.start(0);
+            
+        });
+
+        delete editor.colorview;
+        delete css_editor.colorview;
+
+    } else {
+        editor.colorview = AceColorPicker.load(ace, editor);
+        css_editor.colorview = AceColorPicker.load(ace, css_editor);
     }
 }

--- a/build_staging/style.css
+++ b/build_staging/style.css
@@ -302,11 +302,14 @@ a {
     color: white;
 }
 
+.panel-title-tabs {
+    white-space: nowrap;
+}
+
 .panel-options {
     float: right;
     opacity: 0.8;
     margin-right: 5px;
-    white-space: nowrap;
 }
 
 .ace_editor {
@@ -460,6 +463,10 @@ a {
         -ms-flex-direction: column;
         -o-flex-direction: column;
         flex-direction: column;
+    }
+
+    #titles, .field-title {
+        font-size: 13pt;
     }
     
     #titles div {


### PR DESCRIPTION
Once again got distracted by thinking about quality of life improvements instead of actually doing any actual html editing.

Added a QOL code formatter ([https://github.com/beautify-web/js-beautify](https://github.com/beautify-web/js-beautify))

This is a fairly simple implementation and the options for both html_formatter and css_formatters are currently hard coded. There _could_ be a possibility for the user to choose the formatting options themselves, but I feel like having just a simple option is fine. (The options were generated in ([https://beautifier.io/](https://beautifier.io/)))