### PR TITLE
Debug code jumping to blurb section

### DIFF
--- a/build_staging/script.js
+++ b/build_staging/script.js
@@ -756,18 +756,20 @@ function switchTo(mode) {
     frame.contentWindow.switchTo(mode);
 }
 
-function toggleBlurb(mode) {
-    if( $("#wysiwyg").prop("checked") ) return;
+function toggleBlurb(toMode) {
     clearTimeout(lastRequest);
+    const currentMode = editor.isBlurb ? "blurb" : "html";
+    if(toMode == currentMode) return;
+    if( $("#wysiwyg").prop("checked") ) return;
 
-    if(mode == "html") {
+    if(toMode == "html") {
         $("#wysiwyg").prop("disabled", false);
         const request = requestFromDB("html");
         request.onsuccess = (e) => {
             $("#html-tab").removeClass("text-dark");
             $("#blurb-tab").addClass("text-dark");
             editor.setValue(e.target.result.code);
-            editor.isBlurb = !editor.isBlurb;
+            editor.isBlurb = false;
         }
     } else {
         $("#wysiwyg").prop("disabled", true);
@@ -776,7 +778,7 @@ function toggleBlurb(mode) {
             $("#blurb-tab").removeClass("text-dark");
             $("#html-tab").addClass("text-dark");
             editor.setValue(e.target.result.code);
-            editor.isBlurb = !editor.isBlurb;
+            editor.isBlurb = true;
         }
     }
 }

--- a/build_staging/script.js
+++ b/build_staging/script.js
@@ -723,7 +723,7 @@ function renderProfileMeta(data) {
 
 
 /**************************************
-    vvv  UI functionality  vvv
+ UI functionality
 **************************************/
 
 function showInfo() {
@@ -739,7 +739,7 @@ function hardReset() {
 }
 
 /**************************************
-    vvv  UI toggles  vvv
+ UI toggles
 **************************************/
 
 function toggleTheme(theme) {
@@ -757,8 +757,11 @@ function switchTo(mode) {
 }
 
 function toggleBlurb(mode) {
+    if( $("#wysiwyg").prop("checked") ) return;
     clearTimeout(lastRequest);
+
     if(mode == "html") {
+        $("#wysiwyg").prop("disabled", false);
         const request = requestFromDB("html");
         request.onsuccess = (e) => {
             $("#html-tab").removeClass("text-dark");
@@ -767,6 +770,7 @@ function toggleBlurb(mode) {
             editor.isBlurb = !editor.isBlurb;
         }
     } else {
+        $("#wysiwyg").prop("disabled", true);
         const request = requestFromDB("blurb");
         request.onsuccess = (e) => {
             $("#blurb-tab").removeClass("text-dark");
@@ -959,6 +963,9 @@ function toggleColorpicker() {
 }
 
 function toggleWYSIWYG(toState) {
+    // Don't allow WYSIWYG if currently on blurb
+    if( editor.isBlurb ) return;
+
     frame.contentWindow.toggleWYSIWYG(toState);
     if(toState === true) {
         editor.setReadOnly(true);


### PR DESCRIPTION
This PR addresses 2 bugs: 1. when clicking the HTML/Blurb tab headers, the `isBlurb` flag would be toggled on the editor even if its state did not change; 2. clicking on the Blurb tab while in WYSIWYG mode would cause the HTML code to migrate to the blurb section, replacing the existing blurb content.